### PR TITLE
Fix removesection logic

### DIFF
--- a/src/api/search.api.ts
+++ b/src/api/search.api.ts
@@ -19,7 +19,7 @@ class SearchAPIClient {
         query: `
           {
             search(termId:"${termId}", query: "${searchQuery}", first: ${first}) {
-              nodes { ... on ClassOccurrence { name subject classId sections { meetings campus }
+              nodes { ... on ClassOccurrence { name subject classId sections { meetings campus seatsCapacity seatsRemaining crn profs }
               }
             }
           }
@@ -62,7 +62,6 @@ class SearchAPIClient {
     const termInfos = response.data.data.termInfos;
     return termInfos;
   }
-
 }
 
 export const SearchAPI = new SearchAPIClient();

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -5,19 +5,23 @@ export interface MeetingTime {
 
 export interface Meeting {
   type: string;
-  times: {[key: string]: MeetingTime[]};
+  times: { [key: string]: MeetingTime[] };
   where: string;
   endDate: number;
   startDate: number;
 }
 
 export interface Section {
+  crn: string;
+  profs: [string];
   /**
    * The reason this is a list of Meeting is because if the times
    * across all meetings aren't the same, they get split into multiple
    * Meeting objects. There's also a "Final Exam" Meeting, specified by
    * 'type', but I've already filtered those out.
    */
+  seatsCapacity: number;
+  seatsRemaining: number;
   meetings: Meeting[];
   name: string;
   campus: string;

--- a/src/components/Course/SectionItem.tsx
+++ b/src/components/Course/SectionItem.tsx
@@ -2,7 +2,7 @@ import { Section } from "../../common/types";
 import { Box } from "@mui/material";
 import WeekDisplay from "./MeetingDisplay/WeekDisplay";
 
-interface SectionItem2Props {
+interface SectionItemProps {
   section: Section;
   name: string;
   sectionIndex: number;
@@ -11,9 +11,8 @@ interface SectionItem2Props {
   setHoverSection: React.Dispatch<React.SetStateAction<Section[]>>;
 }
 
-const SectionItem: React.FC<SectionItem2Props> = ({
+const SectionItem: React.FC<SectionItemProps> = ({
   section,
-  name,
   sectionIndex,
   isSelected,
   onClick,

--- a/src/hooks/usePlans.ts
+++ b/src/hooks/usePlans.ts
@@ -87,7 +87,7 @@ function usePlans() {
     setPlan((oldPlan: Plan) => {
       let newSections = oldPlan.sections;
       newSections = newSections.filter(
-        (oldSection) => JSON.stringify(oldSection) !== JSON.stringify(section)
+        (oldSection) => oldSection.crn !== section.crn
       );
       const newPlan = {
         ...oldPlan,


### PR DESCRIPTION
Because of the off chance that sections' meeting times, places, etc, the wrong section will get removed when this function is called. To fix this, I added the section crn as part of the api since they are always unique. Crn is now compared instead, so this issue should be fixed.

closes #28