### PR TITLE
fixed button squish

### DIFF
--- a/src/components/Course/AddCourse/AddCourseDisplay.tsx
+++ b/src/components/Course/AddCourse/AddCourseDisplay.tsx
@@ -30,11 +30,13 @@ function AddCourseDisplay({
         <div>
           <span style={{ fontWeight: "bold" }}>
             {courseNodeToString(course)}
-          </span> <br/>
+          </span>{" "}
+          <br />
           <span>{course.name}</span>
         </div>
-        <div><AddButton onClick={onClick} disabled={alreadyAdded}></AddButton></div>
-
+        <div>
+          <AddButton onClick={onClick} disabled={alreadyAdded}></AddButton>
+        </div>
       </Box>
     </Box>
   );

--- a/src/components/Course/AddCourse/AddCourseDisplay.tsx
+++ b/src/components/Course/AddCourse/AddCourseDisplay.tsx
@@ -30,10 +30,11 @@ function AddCourseDisplay({
         <div>
           <span style={{ fontWeight: "bold" }}>
             {courseNodeToString(course)}
-          </span>
-          <div>{course.name}</div>
+          </span> <br/>
+          <span>{course.name}</span>
         </div>
-        <AddButton onClick={onClick} disabled={alreadyAdded}></AddButton>
+        <div><AddButton onClick={onClick} disabled={alreadyAdded}></AddButton></div>
+
       </Box>
     </Box>
   );

--- a/src/components/Course/CourseDropdown.tsx
+++ b/src/components/Course/CourseDropdown.tsx
@@ -105,12 +105,12 @@ const CourseDropdown: React.FC<CourseDropDownProps> = ({
                 </span>
                 <div>{course.name}</div>
               </div>
-              <RemoveButton
+              <div><RemoveButton
                 onClick={() => {
                   removeCourse(course);
                   removeCourseSections();
                 }}
-              ></RemoveButton>
+              ></RemoveButton></div>
             </Box>
             <Box
               sx={{

--- a/src/components/Course/CourseDropdown.tsx
+++ b/src/components/Course/CourseDropdown.tsx
@@ -105,12 +105,14 @@ const CourseDropdown: React.FC<CourseDropDownProps> = ({
                 </span>
                 <div>{course.name}</div>
               </div>
-              <div><RemoveButton
-                onClick={() => {
-                  removeCourse(course);
-                  removeCourseSections();
-                }}
-              ></RemoveButton></div>
+              <div>
+                <RemoveButton
+                  onClick={() => {
+                    removeCourse(course);
+                    removeCourseSections();
+                  }}
+                ></RemoveButton>
+              </div>
             </Box>
             <Box
               sx={{


### PR DESCRIPTION
Fixed button squishing for both and when the course name is too long.
Add "div" around button figures in [AddCourseDisply] and [CourseDropdown] to avoid squishing.
closes #19 