### PR TITLE
Drag/drop change width

### DIFF
--- a/src/components/Course/SortableItem.tsx
+++ b/src/components/Course/SortableItem.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { CSS } from "@dnd-kit/utilities";
 import { useSortable } from "@dnd-kit/sortable";
-import { alignProperty } from "@mui/material/styles/cssUtils";
-import { min } from "lodash";
+import { Box } from "@mui/material";
 
 interface SortableItemProps {
   id: string;
@@ -22,13 +21,13 @@ export function SortableItem({ id, children }: SortableItemProps) {
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    width: "100%"
+    width: "100%",
   };
 
   // Pass listeners, attributes, and setNodeRef as a single object
   return (
-    <div ref={setNodeRef} style={style}>
+    <Box ref={setNodeRef} sx={style}>
       {children({ listeners, attributes, setNodeRef })}
-    </div>
+    </Box>
   );
 }

--- a/src/components/Course/SortableItem.tsx
+++ b/src/components/Course/SortableItem.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { CSS } from "@dnd-kit/utilities";
 import { useSortable } from "@dnd-kit/sortable";
+import { alignProperty } from "@mui/material/styles/cssUtils";
+import { min } from "lodash";
 
 interface SortableItemProps {
   id: string;
@@ -20,6 +22,7 @@ export function SortableItem({ id, children }: SortableItemProps) {
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
+    width: "100%"
   };
 
   // Pass listeners, attributes, and setNodeRef as a single object

--- a/src/components/Layout/SidebarContainer.tsx
+++ b/src/components/Layout/SidebarContainer.tsx
@@ -16,7 +16,7 @@ const SidebarContainer: React.FC<SidebarContainerProps> = ({ children }) => {
         overflow: "auto",
         height: "100%",
         width: "100%",
-        backgroundColor: theme.palette.background.default,
+        minWidth : " 230px",
       }}
     >
       {children}

--- a/src/components/Layout/SidebarContainer.tsx
+++ b/src/components/Layout/SidebarContainer.tsx
@@ -16,7 +16,7 @@ const SidebarContainer: React.FC<SidebarContainerProps> = ({ children }) => {
         overflow: "auto",
         height: "100%",
         width: "100%",
-        minWidth : " 230px",
+        backgroundColor: theme.palette.background.default,
       }}
     >
       {children}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -21,8 +21,6 @@ import {
   SortableContext,
   verticalListSortingStrategy,
   sortableKeyboardCoordinates,
-  useSortable,
-  AnimateLayoutChanges,
 } from "@dnd-kit/sortable";
 import { SortableItem } from "../components/Course/SortableItem";
 import { arrayMove } from "../common/utils";
@@ -103,21 +101,21 @@ function Home() {
                   alignItems: "center",
                 }}
               >
-                  {plan.courses.map((course) => (
-                    <SortableItem key={course.classId} id={course.classId}>
-                      {(dragHandleProps) => (
-                        <CourseDropdown
-                          setHoverSection={setHoverSection}
-                          plan={plan}
-                          course={course}
-                          removeCourse={removeCourse}
-                          addSection={addSection}
-                          removeSection={removeSection}
-                          dragHandleProps={dragHandleProps}
-                        />
-                      )}
-                    </SortableItem>
-                  ))}
+                {plan.courses.map((course) => (
+                  <SortableItem key={course.classId} id={course.classId}>
+                    {(dragHandleProps) => (
+                      <CourseDropdown
+                        setHoverSection={setHoverSection}
+                        plan={plan}
+                        course={course}
+                        removeCourse={removeCourse}
+                        addSection={addSection}
+                        removeSection={removeSection}
+                        dragHandleProps={dragHandleProps}
+                      />
+                    )}
+                  </SortableItem>
+                ))}
               </Box>
             </SortableContext>
           </DndContext>
@@ -157,7 +155,7 @@ function Home() {
             <AddPlanModal addPlan={addPlan} setPlan={setPlan}></AddPlanModal>
           </Box>
         </Box>
-        <Box sx={{ width: "75vw" }}>
+        <Box sx={{ width: "70vw" }}>
           <Schedule
             sections={plan.sections}
             hoverSections={hoverSection}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -103,21 +103,21 @@ function Home() {
                   alignItems: "center",
                 }}
               >
-                {plan.courses.map((course) => (
-                  <SortableItem key={course.classId} id={course.classId}>
-                    {(dragHandleProps) => (
-                      <CourseDropdown
-                        setHoverSection={setHoverSection}
-                        plan={plan}
-                        course={course}
-                        removeCourse={removeCourse}
-                        addSection={addSection}
-                        removeSection={removeSection}
-                        dragHandleProps={dragHandleProps}
-                      />
-                    )}
-                  </SortableItem>
-                ))}
+                  {plan.courses.map((course) => (
+                    <SortableItem key={course.classId} id={course.classId}>
+                      {(dragHandleProps) => (
+                        <CourseDropdown
+                          setHoverSection={setHoverSection}
+                          plan={plan}
+                          course={course}
+                          removeCourse={removeCourse}
+                          addSection={addSection}
+                          removeSection={removeSection}
+                          dragHandleProps={dragHandleProps}
+                        />
+                      )}
+                    </SortableItem>
+                  ))}
               </Box>
             </SortableContext>
           </DndContext>


### PR DESCRIPTION
Give a fixed witdth for every course sections(boxs) in <SortableItem.tsx> to make sure boxes keep the same with sidebar width.

Avoid weird text displacement (shifting left) of long course descriptions (when the width is smaller than the longest word in the descrip), by adding a min-width of 230px to the sidebar, according to the longest word I can find through manual tests.

--
Can't find a more appropieate way to deal in a shrot time>>